### PR TITLE
Improve input component

### DIFF
--- a/src/base/styles/form-control.styl
+++ b/src/base/styles/form-control.styl
@@ -20,7 +20,7 @@
       border-color var(--t-color-purple-lighter)
     &[disabled]
       background-color var(--t-color-grey-lighter)
-      color var(--t-color-grey-dark)
+      color var(--t-color-grey-darker)
       border-color var(--t-color-grey-light)
       pointer-events none
   &.t-form-control-invalid

--- a/src/react/components/input/input.doc.js
+++ b/src/react/components/input/input.doc.js
@@ -155,7 +155,10 @@ module.exports = {
           );
         }
       },
-      styles: 'p-external-component-examples-list p-list-item:nth-child(6) input { width: 300px; max-width: 100%; }'
+      styles: `
+        p-external-component-examples-list p-list-item:nth-child(6) .t-form-control { max-width: 100%; }
+        p-external-component-examples-list p-list-item:nth-child(6) input { width: 300px; max-width: 100%; }
+      `
     },
     {
       title: 'Input with autofocus',

--- a/src/vue/components/input/input.doc.js
+++ b/src/vue/components/input/input.doc.js
@@ -140,7 +140,10 @@ module.exports = {
       template: `
       <t-input :validations="validations" placeholder="Enter a programming language" />
       `,
-      styles: 'p-external-component-examples-list p-list-item:nth-child(6) input { width: 300px; max-width: 100%; }'
+      styles: `
+        p-external-component-examples-list p-list-item:nth-child(6) .t-form-control { max-width: 100%; }
+        p-external-component-examples-list p-list-item:nth-child(6) input { width: 300px; max-width: 100%; }
+      `
     },
     {
       title: 'Input with autofocus',


### PR DESCRIPTION
This Pull Request introduces the necessary changes to solve two issues:

- Text color for disabled input was too light on Safari and Firefox. This Pull Request make that darker.
- Input validation example in the documentation shown an input not well fitted in its container on mobile. This Pull Request solves that.

**Preview**

<img width="1031" alt="Screen Shot 2020-09-07 at 12 26 28" src="https://user-images.githubusercontent.com/4738687/92402149-721f3600-f105-11ea-9bf8-9ae8a90a33b3.png">

<img width="304" alt="Screen Shot 2020-09-07 at 12 26 58" src="https://user-images.githubusercontent.com/4738687/92402158-777c8080-f105-11ea-8686-f71da46115a0.png">
