### PR TITLE
Fix Github template typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-name: Dúvida
+name: Question
 about: Use this template to ask for help.
 title: ''
 labels: question


### PR DESCRIPTION
## Issue

Resolves #33 

## Solution

That issue was partially resolved on #34. However, the *Question* template had a typo. This PR fix that.
