### PR TITLE
Create Confirm component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/taslonic",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,9 +1102,9 @@
       }
     },
     "@babel/standalone": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.12.6.tgz",
-      "integrity": "sha512-yA/OV3jN1nhr0JsAdYWAqbeZ7cAOw/6Fh52rxVMzujr0HF4Z3cau0JBzJfQppFfR9IArrUtcqhBu/+Q/IevoyQ==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.12.9.tgz",
+      "integrity": "sha512-7SFBBNPjEZnN3dlnOcTa08XLkGUUmZX6Aab2rdeVBfI/bBaZXRRMx5XIMU8piZMVJI+jxu4j7gu0E/yRWmtS4w==",
       "dev": true
     },
     "@babel/template": {
@@ -1162,16 +1162,37 @@
         "minimist": "^1.2.0"
       }
     },
+    "@glorious/fyzer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@glorious/fyzer/-/fyzer-0.1.2.tgz",
+      "integrity": "sha512-aOeBnnr82YWnjWyuKNAjlpuQw+BR/3p8hkvDG59Fc/z4Rm+VhO+bKF/2Gsj+Acm2zrt2JyNdCmCXQ9lmFep6cg==",
+      "dev": true,
+      "requires": {
+        "shortid": "^2.2.16"
+      },
+      "dependencies": {
+        "shortid": {
+          "version": "2.2.16",
+          "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+          "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+          "dev": true,
+          "requires": {
+            "nanoid": "^2.1.0"
+          }
+        }
+      }
+    },
     "@glorious/pitsby": {
-      "version": "1.29.3",
-      "resolved": "https://registry.npmjs.org/@glorious/pitsby/-/pitsby-1.29.3.tgz",
-      "integrity": "sha512-+MH9qUTwm+idw3TJhpGSeiEx7eN7vrhrrWRA2ANXTAhr6mf4LjEh6TfQd+R4186urEbK6a/g1w2efV1/Hgbqjw==",
+      "version": "1.29.4",
+      "resolved": "https://registry.npmjs.org/@glorious/pitsby/-/pitsby-1.29.4.tgz",
+      "integrity": "sha512-pq3hhVD3GtbnG/XFsc6vsHLitmgIkSQIzeZbOpZfgjXi6FGGEfKoQJnBtMsUupy3FIhV714n5DRzXsBtxbu61w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.6.2",
         "@babel/preset-env": "^7.6.2",
         "@babel/preset-react": "^7.8.3",
         "@babel/standalone": "^7.8.6",
+        "@glorious/fyzer": "^0.1.2",
         "@uirouter/angularjs": "^1.0.20",
         "axios": "^0.18.1",
         "babel-jest": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/taslonic",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "A glorious UI library available for React and Vue",
   "files": [
     "dist/**/*.*"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.7.4",
-    "@glorious/pitsby": "^1.29.3",
+    "@glorious/pitsby": "^1.29.4",
     "@vue/test-utils": "^1.0.0-beta.32",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.3.0",

--- a/src/base/constants/confirm.js
+++ b/src/base/constants/confirm.js
@@ -1,0 +1,2 @@
+export const CANCEL_BUTTON_TEXT = 'Cancel';
+export const CONFIRM_BUTTON_TEXT = 'Confirm';

--- a/src/base/services/dialog/dialog.js
+++ b/src/base/services/dialog/dialog.js
@@ -1,11 +1,10 @@
 import floatingContainerService from '@base/services/floating-container/floating-container';
-import idService from '@base/services/id/id';
 
 const _public = {};
 
-_public.buildWrapper = () => {
-  const container = floatingContainerService.build('dialog-container');
-  const wrapper = buildWrapper(idService.generate());
+_public.buildWrapper = name => {
+  const container = floatingContainerService.build();
+  const wrapper = buildWrapper(name);
   container.appendChild(wrapper);
   preventBodyScroll();
   return wrapper;
@@ -13,19 +12,17 @@ _public.buildWrapper = () => {
 
 _public.destroy = wrapper => {
   setTimeout(() => {
-    if(hasOnlyOneDialogOpen()) releaseBodyScroll();
+    if(hasOnlyOneDialogOpen(wrapper)) releaseBodyScroll();
     wrapper.remove();
   });
 };
 
-function buildWrapper(id) {
+function buildWrapper(name = 'dialog') {
   const wrapper = document.createElement('div');
-  wrapper.setAttribute(getWrapperCustomAttribute(), id);
+  const wrapperFullName = `${name}-wrapper`;
+  wrapper.setAttribute(`data-${wrapperFullName}`, '');
+  wrapper.classList.add(`t-${wrapperFullName}`);
   return wrapper;
-}
-
-function getWrapperCustomAttribute() {
-  return 'data-dialog-wrapper';
 }
 
 function preventBodyScroll(){
@@ -49,9 +46,8 @@ function handleBodyCssClass(action, cssClass){
   document.body.classList[action](cssClass);
 }
 
-function hasOnlyOneDialogOpen(){
-  const selector = `[${getWrapperCustomAttribute()}]`;
-  return document.querySelectorAll(selector).length === 1;
+function hasOnlyOneDialogOpen(wrapper){
+  return wrapper.parentElement.children.length === 1;
 }
 
 export default _public;

--- a/src/base/services/dialog/dialog.test.js
+++ b/src/base/services/dialog/dialog.test.js
@@ -12,9 +12,17 @@ describe('Dialog Service', () => {
     return 't-dialog-open';
   }
 
-  it('should build a dialog wrapper contained in a dialog container', () => {
+  it('should build a dialog wrapper contained in a floating container', () => {
     const wrapper = dialogService.buildWrapper();
-    expect(wrapper.parentElement.getAttribute('class')).toEqual('t-dialog-container');
+    const floatingContainerEl = wrapper.parentElement;
+    expect(wrapper.getAttribute('class')).toEqual('t-dialog-wrapper');
+    expect(floatingContainerEl.getAttribute('class')).toEqual('t-floating-container');
+    expect(floatingContainerEl.getAttribute('data-floating-container')).toBeDefined();
+  });
+
+  it('should optionally name wrapper contained in a floating container', () => {
+    const wrapper = dialogService.buildWrapper('confirm');
+    expect(wrapper.getAttribute('class')).toEqual('t-confirm-wrapper');
   });
 
   it('should be able to prevent body scroll', () => {

--- a/src/base/services/floating-container/floating-container.js
+++ b/src/base/services/floating-container/floating-container.js
@@ -5,7 +5,7 @@ _public.build = id => {
   return container;
 };
 
-function getContainer(id){
+function getContainer(id = 'floating-container'){
   const container = document.querySelector(`[${getContainerCustomAttrName(id)}]`);
   return container ? container : buildContainer(id);
 }

--- a/src/base/services/floating-container/floating-container.test.js
+++ b/src/base/services/floating-container/floating-container.test.js
@@ -6,15 +6,13 @@ describe('Floating Container Service', () => {
   });
 
   it('should build a base css class according given id', () => {
-    const id = 'toaster';
-    const container = floatingContainerService.build(id);
-    expect(container.getAttribute('class')).toEqual('t-toaster');
+    const container = floatingContainerService.build();
+    expect(container.getAttribute('class')).toEqual('t-floating-container');
   });
 
   it('should append no more than one container on body', () => {
-    const id = 'toaster';
-    floatingContainerService.build(id);
-    floatingContainerService.build(id);
-    expect(document.querySelectorAll('[data-toaster]').length).toEqual(1);
+    floatingContainerService.build();
+    floatingContainerService.build();
+    expect(document.querySelectorAll('[data-floating-container]').length).toEqual(1);
   });
 });

--- a/src/base/styles/_index.js
+++ b/src/base/styles/_index.js
@@ -3,6 +3,7 @@ import './banner.styl';
 import './button.styl';
 import './close-button.styl';
 import './col.styl';
+import './confirm.styl';
 import './container.styl';
 import './dialog.styl';
 import './field.styl';

--- a/src/base/styles/confirm.styl
+++ b/src/base/styles/confirm.styl
@@ -1,0 +1,27 @@
+@require '_mixins'
+
+.t-confirm-wrapper
+  .t-dialog-header
+    padding 0
+
+.t-confirm-footer
+  display flex
+  flex-direction column-reverse
+  margin-top 30px
+  .t-button
+    width 100%
+  .t-button:first-child
+    margin 10px 0 0 0
+
++breakpoint('sm')
+  .t-confirm-footer
+    flex-direction row
+    justify-content flex-end
+    .t-button
+      width auto
+      min-width 120px
+    .t-button
+      &:first-child
+        margin 0
+      &:not(:first-child)
+        margin 0 0 0 10px

--- a/src/base/styles/dialog.styl
+++ b/src/base/styles/dialog.styl
@@ -2,7 +2,7 @@
 
 $backdrop-color = #333333
 :root
-  --t-dialog-spacing 120px
+  --t-dialog-spacing 60px
 
 @keyframes fadin
   0%
@@ -61,3 +61,9 @@ $backdrop-color = #333333
 
 .t-dialog-open
   overflow hidden
+
++breakpoint('sm')
+  .t-dialog-backdrop
+    padding-bottom calc(var(--t-dialog-spacing) * 2)
+  .t-dialog
+    margin calc(var(--t-dialog-spacing) * 2) auto 0

--- a/src/react/components/confirm/confirm.js
+++ b/src/react/components/confirm/confirm.js
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { CANCEL_BUTTON_TEXT, CONFIRM_BUTTON_TEXT } from '@base/constants/confirm';
+import keyboardSubscriptionService from '@base/services/keyboardSubscription/keyboardSubscription';
+import { Button } from '@react/components/button/button';
+
+export const Confirm = ({
+  children,
+  cancelButtonText = CANCEL_BUTTON_TEXT,
+  confirmButtonText = CONFIRM_BUTTON_TEXT,
+  onCancel = () => {},
+  onConfirm = () => {}
+}) => {
+  useEffect(() => {
+    const { subscribe, unsubscribe } = keyboardSubscriptionService;
+    const keyCodes = { esc: 27, enter: 13 };
+    const escSubcriptionId = subscribe(keyCodes.esc, onCancel);
+    const enterSubcriptionId = subscribe(keyCodes.enter, onConfirm);
+    return () => {
+      unsubscribe(escSubcriptionId);
+      unsubscribe(enterSubcriptionId);
+    };
+  }, [onCancel, onConfirm]);
+
+  return (
+    <div className="t-confirm-content">
+      { children }
+      <div className="t-confirm-footer">
+        <Button onClick={ onCancel }>
+          { cancelButtonText }
+        </Button>
+        <Button theme="primary" onClick={ onConfirm }>
+          { confirmButtonText }
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/react/components/confirm/confirm.test.js
+++ b/src/react/components/confirm/confirm.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { getRootElProp } from '@react/services/testing/testing';
+import testingService from '@base/services/testing/testing';
+import { Confirm } from './confirm';
+
+describe('Confirm', () => {
+  function mountComponent({ content, cancelButtonText, confirmButtonText, onCancel, onConfirm } = {}){
+    return mount(
+      <Confirm
+        cancelButtonText={ cancelButtonText }
+        confirmButtonText={ confirmButtonText }
+        onCancel={ onCancel }
+        onConfirm={ onConfirm }>
+        { content }
+      </Confirm>
+    );
+  }
+
+  function getButton(wrapper, type){
+    const index = type == 'cancel' ? 0 : 1;
+    return wrapper.find('button').at(index);
+  }
+
+  it('should have base css class', () => {
+    const wrapper = mountComponent();
+    expect(getRootElProp(wrapper, 'className')).toEqual('t-confirm-content');
+  });
+
+  it('should render custom content', () => {
+    const wrapper = mountComponent({ content: <p>Really?</p> });
+    expect(wrapper.find('p').text()).toContain('Really?');
+  });
+
+  it('should cancel button text be "Cancel" by default', () => {
+    const wrapper = mountComponent();
+    expect(getButton(wrapper, 'cancel').text()).toContain('Cancel');
+  });
+
+  it('should optionally customize cancel button text', () => {
+    const wrapper = mountComponent({ cancelButtonText: 'Abort' });
+    expect(getButton(wrapper, 'cancel').text()).toContain('Abort');
+  });
+
+  it('should confirm button text be "Confirm" by default', () => {
+    const wrapper = mountComponent();
+    expect(getButton(wrapper, 'confirm').text()).toContain('Confirm');
+  });
+
+  it('should optionally customize confirm button text', () => {
+    const wrapper = mountComponent({ confirmButtonText: 'Go' });
+    expect(getButton(wrapper, 'confirm').text()).toContain('Go');
+  });
+
+  it('should execute cancel callback on cancel button click', () => {
+    const onCancel = jest.fn();
+    const wrapper = mountComponent({ onCancel });
+    getButton(wrapper, 'cancel').simulate('click');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should execute cancel callback on Esc keydown', () => {
+    const escKeyCode = 27;
+    const onCancel = jest.fn();
+    mountComponent({ onCancel });
+    testingService.simulateKeydown(escKeyCode);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should execute confirm callback on confirm button click', () => {
+    const onConfirm = jest.fn();
+    const wrapper = mountComponent({ onConfirm });
+    getButton(wrapper, 'confirm').simulate('click');
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('should execute confirm callback on Enter keydown', () => {
+    const enterKeyCode = 13;
+    const onConfirm = jest.fn();
+    mountComponent({ onConfirm });
+    testingService.simulateKeydown(enterKeyCode);
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/src/react/components/dialog/dialog.js
+++ b/src/react/components/dialog/dialog.js
@@ -2,11 +2,15 @@ import React, { useEffect } from 'react';
 import keyboardSubscriptionService from '@base/services/keyboardSubscription/keyboardSubscription';
 import { Button } from '@react/components/button/button';
 
-export const Dialog = ({ width, title, onClose, children }) => {
+export const Dialog = ({ width, title, hideCloseButton, onClose, children }) => {
+  document.activeElement.blur();
+
   useEffect(() => {
-    const escKeyCode = 27;
-    const id = keyboardSubscriptionService.subscribe(escKeyCode, onClose);
-    return () => keyboardSubscriptionService.unsubscribe(id);
+    if(!hideCloseButton) {
+      const escKeyCode = 27;
+      const id = keyboardSubscriptionService.subscribe(escKeyCode, onClose);
+      return () => keyboardSubscriptionService.unsubscribe(id);
+    }
   }, []);
 
   return (
@@ -17,15 +21,7 @@ export const Dialog = ({ width, title, onClose, children }) => {
         data-dialog>
         <div className="t-dialog-header">
           { buildTitle(title) }
-          <span className="t-dialog-close-button-container">
-            <Button
-              aria-label="close"
-              theme="lookless"
-              onClick={ onClose }
-              data-dialog-close-button>
-              ×
-            </Button>
-          </span>
+          { !hideCloseButton && buildCloseButton(onClose) }
         </div>
         <div className="t-dialog-content">
           { children }
@@ -46,4 +42,18 @@ function buildTitle(title){
         { title }
       </h2>
     );
+}
+
+function buildCloseButton(onClose){
+  return (
+    <span className="t-dialog-close-button-container">
+      <Button
+        aria-label="close"
+        theme="lookless"
+        onClick={ onClose }
+        data-dialog-close-button>
+        ×
+      </Button>
+    </span>
+  );
 }

--- a/src/react/components/dialog/dialog.test.js
+++ b/src/react/components/dialog/dialog.test.js
@@ -6,9 +6,13 @@ import keyboardSubscriptionService from '@base/services/keyboardSubscription/key
 import { Dialog } from './dialog';
 
 describe('Dialog', () => {
-  function mountComponent({ width, title, onClose = () => {}, children } = {}){
+  function mountComponent({ width, title, hideCloseButton, onClose = () => {}, children } = {}){
     return mount(
-      <Dialog title={ title } width={ width } onClose={ onClose }>
+      <Dialog
+        title={ title }
+        width={ width }
+        hideCloseButton={ hideCloseButton }
+        onClose={ onClose }>
         { children }
       </Dialog>
     );
@@ -17,6 +21,12 @@ describe('Dialog', () => {
   it('should have appropriate css class', () => {
     const wrapper = mountComponent();
     expect(wrapper.find('[data-dialog]').prop('className')).toEqual('t-dialog');
+  });
+
+  it('should deactivate any active element on document on create', () => {
+    document.activeElement.blur = jest.fn();
+    mountComponent();
+    expect(document.activeElement.blur).toHaveBeenCalled();
   });
 
   it('should contain a backdrop', () => {
@@ -62,6 +72,15 @@ describe('Dialog', () => {
     mountComponent({ onClose });
     testingService.simulateKeydown(escKeyCode);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should not execute close callback on esc keydown event if close button is hidden', () => {
+    const escKeyCode = 27;
+    const onClose = jest.fn();
+    const wrapper = mountComponent({ onClose, hideCloseButton: true });
+    testingService.simulateKeydown(escKeyCode);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-dialog-close-button]').length).toEqual(0);
   });
 
   it('should stop listening esc keydown event on unmount', () => {

--- a/src/react/components/form/form.js
+++ b/src/react/components/form/form.js
@@ -86,7 +86,7 @@ export const Form = ({
       {...rest}>
       { handleLoader(fetching) }
       { handleBanner(banner) }
-      <div className="t-form-content">
+      <div className="t-form-content" aria-live="polite" aria-busy={fetching} data-form-content>
         { children }
       </div>
     </form>

--- a/src/react/components/form/form.test.js
+++ b/src/react/components/form/form.test.js
@@ -88,6 +88,26 @@ describe('Form Banner', () => {
     });
   });
 
+  it('should form content be busy on fetch', done => {
+    const onFetch = jest.fn(() => new PromiseMock('success', { shouldAbort: true }));
+    mount({ onFetch }, element => {
+      const formContentEl = element.querySelector('[data-form-content]');
+      expect(formContentEl.getAttribute('aria-live')).toEqual('polite');
+      expect(formContentEl.getAttribute('aria-busy')).toEqual('true');
+      done();
+    });
+  });
+
+  it('should form content not be busy on fetch complete', done => {
+    const onFetch = jest.fn(() => new PromiseMock('success'));
+    mount({ onFetch }, element => {
+      const formContentEl = element.querySelector('[data-form-content]');
+      expect(formContentEl.getAttribute('aria-live')).toEqual('polite');
+      expect(formContentEl.getAttribute('aria-busy')).toEqual('false');
+      done();
+    });
+  });
+
   it('should hide loader on fetch complete', done => {
     const onFetch = jest.fn(() => new PromiseMock('success'));
     mount({ onFetch }, element => {

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,9 +1,11 @@
 import * as components from '@react/components';
-import toaster from '@react/services/toaster/toaster';
+import confirm from '@react/services/confirm/confirm';
 import dialog from '@react/services/dialog/dialog';
+import toaster from '@react/services/toaster/toaster';
 
 export default {
   ...components,
-  toaster,
-  dialog
+  confirm,
+  dialog,
+  toaster
 };

--- a/src/react/services/confirm/confirm.doc.js
+++ b/src/react/services/confirm/confirm.doc.js
@@ -1,0 +1,194 @@
+module.exports = {
+  name: 'Confirm',
+  description: 'Service to open confirmation dialogs.',
+  methods: [
+    {
+      name: 'open({ title, content, width, cancelButtonText, confirmButtonText, onCancel, onConfirm })',
+      params: [
+        {
+          name: 'content',
+          type: 'String, React Node',
+          values: 'Any',
+          description: 'Content to be shown in the dialog.',
+          required: true
+        },
+        {
+          name: 'title',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as confirm title.'
+        },
+        {
+          name: 'width',
+          type: 'String',
+          values: 'Any',
+          description: 'Sets how wide dialog can be.'
+        },
+        {
+          name: 'cancelButtonText',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as cancel button text'
+        },
+        {
+          name: 'confirmButtonText',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as confirm button text'
+        },
+        {
+          name: 'onCancel',
+          type: 'Function',
+          values: 'Any',
+          description: 'Listener to be executed on cancel button click'
+        },
+        {
+          name: 'onConfirm',
+          type: 'Function',
+          values: 'Any',
+          description: 'Listener to be executed on confirm button click',
+          required: true
+        }
+      ]
+    }
+  ],
+  examples: [
+    {
+      title: 'Default Confirm',
+      controller: function(){
+        const { Button, confirm, toaster } = taslonicReact;
+
+        return function(){
+          const openConfirmation = () => {
+            confirm.open({
+              content: 'Are you sure?',
+              onConfirm: () => setTimeout(() => toaster.pop({
+                theme: 'success',
+                title: 'Confirmed!',
+                message: 'You have confirmed.'
+              }), 300)
+            });
+          };
+
+          return (
+            <Button onClick={openConfirmation}>
+              Confirm
+            </Button>
+          );
+        }
+      }
+    },
+    {
+      title: 'Confirm with Title',
+      controller: function(){
+        const { Button, confirm, toaster } = taslonicReact;
+
+        return function(){
+          const openConfirmation = () => {
+            confirm.open({
+              content: 'Are you sure you want to delete your account?',
+              title: 'Delete Account',
+              onConfirm: () => setTimeout(() => toaster.pop({
+                theme: 'success',
+                title: 'Confirmed!',
+                message: 'You have confirmed.'
+              }), 300)
+            });
+          };
+
+          return (
+            <Button onClick={openConfirmation}>
+              Confirm
+            </Button>
+          );
+        }
+      }
+    },
+    {
+      title: 'Confirm with custom width',
+      description: 'Default confirm stretches up to 400px, but you can optionally set how wide it can be.',
+      controller: function(){
+        const { Button, confirm, toaster } = taslonicReact;
+
+        return function(){
+          const openConfirmation = () => {
+            confirm.open({
+              content: (
+               <p>
+                 This Confirm stretches up to <strong>700px</strong>.
+                 On narrower screens it will fit properly.
+               </p>
+              ),
+              title: 'Ther Wider Confirm',
+              width: '700px',
+              onConfirm: () => setTimeout(() => toaster.pop({
+                theme: 'success',
+                title: 'Confirmed!',
+                message: 'You have confirmed.'
+              }), 300)
+            });
+          };
+
+          return (
+            <Button onClick={openConfirmation}>
+              Confirm
+            </Button>
+          );
+        }
+      }
+    },
+    {
+      title: 'Confirm with custom button texts',
+      controller: function(){
+        const { Button, confirm, toaster } = taslonicReact;
+
+        return function(){
+          const openConfirmation = () => {
+            confirm.open({
+              content: 'Are you sure you want to send those invites?',
+              title: 'Invitation',
+              confirmButtonText: 'Yes, send them all!',
+              cancelButtonText: 'No, wait.',
+              onConfirm: () => setTimeout(() => toaster.pop({
+                theme: 'success',
+                title: 'Confirmed!',
+                message: 'You have confirmed.'
+              }), 300)
+            });
+          };
+
+          return (
+            <Button onClick={openConfirmation}>
+              Confirm
+            </Button>
+          );
+        }
+      }
+    },
+    {
+      title: 'Confirm with cancel listener',
+      controller: function(){
+        const { Button, confirm, toaster } = taslonicReact;
+
+        return function(){
+          const openConfirmation = () => {
+            confirm.open({
+              content: 'Are you sure?',
+              onCancel: () => popToast('Cancelled', 'You have cancelled.'),
+              onConfirm: () => popToast('Confirmed!', 'You have confirmed.', 'success')
+            });
+          };
+          const popToast = (title, message, theme) => {
+            setTimeout(() => toaster.pop({ theme, title, message }), 300)
+          }
+
+          return (
+            <Button onClick={openConfirmation}>
+              Confirm
+            </Button>
+          );
+        }
+      }
+    }
+  ]
+}

--- a/src/react/services/confirm/confirm.js
+++ b/src/react/services/confirm/confirm.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Confirm } from '@react/components/confirm/confirm';
+import dialogService from '@react/services/dialog/dialog';
+
+const _public = {};
+
+_public.open = ({
+  title,
+  width = '400px',
+  content,
+  cancelButtonText,
+  confirmButtonText,
+  onCancel,
+  onConfirm
+} = {}) => {
+  const dialog = dialogService.open({
+    title,
+    width,
+    content: (
+      <Confirm
+        cancelButtonText={cancelButtonText}
+        confirmButtonText={confirmButtonText}
+        onCancel={() => handleCallbackOption(onCancel, dialog.close)}
+        onConfirm={() => handleCallbackOption(onConfirm, dialog.close)}>
+        { content }
+      </Confirm>
+    ),
+    name: 'confirm',
+    hideCloseButton: true
+  });
+};
+
+function handleCallbackOption(callback, closeDialog){
+  callback && callback();
+  closeDialog();
+}
+
+export default _public;

--- a/src/react/services/confirm/confirm.test.js
+++ b/src/react/services/confirm/confirm.test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import dialogService from '@react/services/dialog/dialog';
+import confirmService from './confirm';
+
+jest.useFakeTimers();
+
+describe('Confirm Service', () => {
+  beforeEach(() => {
+    jest.spyOn(dialogService, 'open');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function getButton(type){
+    const index = type == 'cancel' ? 0 : 1;
+    return document.querySelectorAll('button')[index];
+  }
+
+  it('should render a custom content', () => {
+    const content = <p>Hello!</p>;
+    confirmService.open({ content });
+    expect(document.querySelector('p').textContent).toEqual('Hello!');
+  });
+
+  it('should open a dialog with confirm name', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'confirm' })
+    );
+  });
+
+  it('should open a dialog without close button', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ hideCloseButton: true })
+    );
+  });
+
+  it('should open a dialog 400px wide by default', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ width: '400px' })
+    );
+  });
+
+  it('should optionally open a dialog with custom width', () => {
+    const width = '300px';
+    confirmService.open({ width });
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ width: '300px' })
+    );
+  });
+
+  it('should optionally open a dialog with title', () => {
+    const title = 'Custom Title';
+    confirmService.open({ title });
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ title })
+    );
+  });
+
+  it('should execute cancel callback on cancel button click', () => {
+    const onCancel = jest.fn();
+    confirmService.open({ onCancel });
+    getButton('cancel').click();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should close dialog on cancel button click', () => {
+    const content = <p>Hello!</p>;
+    confirmService.open({ content });
+    getButton('cancel').click();
+    jest.runOnlyPendingTimers();
+    expect(document.querySelector('p')).toEqual(null);
+  });
+
+  it('should optionally set custom cancel button text', () => {
+    const cancelButtonText = 'Abort';
+    confirmService.open({ cancelButtonText });
+    expect(getButton('cancel').textContent.trim()).toEqual(cancelButtonText);
+  });
+
+  it('should execute confirm callback on confirm button click', () => {
+    const onConfirm = jest.fn();
+    confirmService.open({ onConfirm });
+    getButton('confirm').click();
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('should optionally set custom confirm button text', () => {
+    const confirmButtonText = 'Go!';
+    confirmService.open({ confirmButtonText });
+    expect(getButton('confirm').textContent.trim()).toEqual(confirmButtonText);
+  });
+
+  it('should close dialog on confirm button click', () => {
+    const content = <p>Hello!</p>;
+    confirmService.open({ content });
+    getButton('confirm').click();
+    jest.runOnlyPendingTimers();
+    expect(document.querySelector('p')).toEqual(null);
+  });
+});

--- a/src/react/services/dialog/dialog.doc.js
+++ b/src/react/services/dialog/dialog.doc.js
@@ -3,7 +3,7 @@ module.exports = {
   description: 'Service to open dialogs.',
   methods: [
     {
-      name: 'open({ title, content, width, onClose })',
+      name: 'open({ title, content, width, hideCloseButton, onClose })',
       params: [
         {
           name: 'content',
@@ -23,6 +23,12 @@ module.exports = {
           type: 'String',
           values: 'Any',
           description: 'Sets how wide dialog can be.'
+        },
+        {
+          name: 'hideCloseButton',
+          type: 'Boolean',
+          values: 'true, false',
+          description: 'Hides dialog close button.'
         },
         {
           name: 'onClose',
@@ -127,17 +133,39 @@ module.exports = {
     },
     {
       title: 'Dialog closed programmatically',
+      description: 'You can optionally hide the dialog close button and take full control on how and when to close the dialog.',
       controller: function(){
-        const { useState } = React;
+        const { useState, useEffect } = React;
         const { Button, dialog } = taslonicReact;
 
         return function(){
+          let selfClosingDialog;
+
+          const DialogContent = () => {
+            const [count, setCount] = useState(5);
+
+            useEffect(() => {
+              const interval = window.setInterval(() => {
+                const newCount = count - 1;
+                if(newCount === 0) selfClosingDialog.close();
+                else setCount(newCount)
+              }, 1000);
+              return () => window.clearInterval(interval);
+            }, [count, setCount])
+
+            return (
+              <span>
+                This dialog will close in <strong>{count}</strong> seconds...
+              </span>
+            );
+          }
+
           const openDialog = () => {
-            const selfClosingDialog = dialog.open({
-              content: 'This dialog will close in 3 seconds...',
+            selfClosingDialog = dialog.open({
+              content: <DialogContent />,
               title: 'Self Closing Dialog',
+              hideCloseButton: true
             });
-            setTimeout(() => selfClosingDialog.close(), 3000);
           };
 
           return <Button onClick={openDialog}>Open Dialog</Button>;

--- a/src/react/services/dialog/dialog.js
+++ b/src/react/services/dialog/dialog.js
@@ -5,16 +5,20 @@ import componentBuilder from '@react/builders/component/component';
 
 const _public = {};
 
-_public.open = ({ title, width, onClose, content } = {}) => {
-  const wrapper = dialogService.buildWrapper();
-  const dialog = buildDialog({ wrapper, title, width, onClose, content });
+_public.open = ({ title, width, onClose, content, name, hideCloseButton } = {}) => {
+  const wrapper = dialogService.buildWrapper(name);
+  const dialog = buildDialog({ wrapper, title, width, onClose, content, hideCloseButton });
   componentBuilder.build(dialog, wrapper);
   return { close: () => destroy(wrapper, onClose) };
 };
 
-function buildDialog({ wrapper, title, width, onClose, content }) {
+function buildDialog({ wrapper, title, width, onClose, content, hideCloseButton }) {
   return (
-    <Dialog title={ title } width={ width } onClose={ () => destroy(wrapper, onClose) }>
+    <Dialog
+      title={ title }
+      width={ width }
+      hideCloseButton={hideCloseButton}
+      onClose={ () => destroy(wrapper, onClose) }>
       { content }
     </Dialog>
   );

--- a/src/react/services/dialog/dialog.test.js
+++ b/src/react/services/dialog/dialog.test.js
@@ -25,11 +25,21 @@ describe('Dialog Service', () => {
     expect(document.querySelector('[data-dialog]').style.maxWidth).toEqual(width);
   });
 
+  it('should optionally set a custom dialog wrapper name', () => {
+    dialogService.open({ name: 'confirm' });
+    expect(document.querySelector('[data-confirm-wrapper]')).toBeDefined();
+  });
+
   it('should execute close callback on close', () => {
     const onClose = jest.fn();
     dialogService.open({ onClose });
     document.querySelector('[aria-label="close"]').click();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should optionally not render close button', () => {
+    dialogService.open({ hideCloseButton: true });
+    expect(document.querySelector('[aria-label="close"]')).toEqual(null);
   });
 
   it('should destroy dialog', () => {

--- a/src/vue/components/confirm/confirm.html
+++ b/src/vue/components/confirm/confirm.html
@@ -1,0 +1,11 @@
+<div class="t-confirm-content">
+  <slot></slot>
+  <div class="t-confirm-footer">
+    <t-button @click="onCancel">
+      {{ cancelButtonText }}
+    </t-button>
+    <t-button theme="primary" @click="onConfirm">
+      {{ confirmButtonText }}
+    </t-button>
+  </div>
+</div>

--- a/src/vue/components/confirm/confirm.js
+++ b/src/vue/components/confirm/confirm.js
@@ -1,0 +1,35 @@
+import { CANCEL_BUTTON_TEXT, CONFIRM_BUTTON_TEXT } from '@base/constants/confirm';
+import keyboardSubscriptionService from '@base/services/keyboardSubscription/keyboardSubscription';
+import { button } from '@vue/components/button/button';
+import template from './confirm.html';
+
+export const confirm = {
+  name: 't-confirm',
+  components: {
+    tButton: button
+  },
+  props: {
+    cancelButtonText: { default: CANCEL_BUTTON_TEXT },
+    confirmButtonText: { default: CONFIRM_BUTTON_TEXT },
+    onCancel: { default: function(){ return () => {}; } },
+    onConfirm: { default: function(){ return () => {}; } }
+  },
+  data(){
+    return {
+      escSubcriptionId: null,
+      enterSubscriptionId: null
+    };
+  },
+  created(){
+    const { subscribe } = keyboardSubscriptionService;
+    const keycodes = { esc: 27, enter: 13 };
+    this.escSubcriptionId = subscribe(keycodes.esc, () => this.onCancel());
+    this.enterSubscriptionId = subscribe(keycodes.enter, () => this.onConfirm());
+  },
+  beforeDestroy(){
+    const { unsubscribe } = keyboardSubscriptionService;
+    unsubscribe(this.escSubcriptionId);
+    unsubscribe(this.enterSubscriptionId);
+  },
+  template
+};

--- a/src/vue/components/confirm/confirm.test.js
+++ b/src/vue/components/confirm/confirm.test.js
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils';
+import testingService from '@base/services/testing/testing';
+import { confirm } from './confirm';
+
+describe('Confirm', () => {
+  function mountComponent(propsData = {}, content = ''){
+    return mount(confirm, { propsData, slots: { default: content } });
+  }
+
+  function getButton(wrapper, type){
+    const index = type == 'cancel' ? 0 : 1;
+    return wrapper.findAll('button').at(index);
+  }
+
+  it('should have base css class', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.classes()).toContain('t-confirm-content');
+  });
+
+  it('should render custom content', () => {
+    const wrapper = mountComponent({}, '<p>Really?</p>');
+    expect(wrapper.find('p').text()).toContain('Really?');
+  });
+
+  it('should cancel button text be "Cancel" by default', () => {
+    const wrapper = mountComponent();
+    expect(getButton(wrapper, 'cancel').text()).toContain('Cancel');
+  });
+
+  it('should optionally customize cancel button text', () => {
+    const wrapper = mountComponent({ cancelButtonText: 'Abort' });
+    expect(getButton(wrapper, 'cancel').text()).toContain('Abort');
+  });
+
+  it('should confirm button text be "Confirm" by default', () => {
+    const wrapper = mountComponent();
+    expect(getButton(wrapper, 'confirm').text()).toContain('Confirm');
+  });
+
+  it('should optionally customize confirm button text', () => {
+    const wrapper = mountComponent({ confirmButtonText: 'Go' });
+    expect(getButton(wrapper, 'confirm').text()).toContain('Go');
+  });
+
+  it('should execute cancel callback on cancel button click', () => {
+    const onCancel = jest.fn();
+    const wrapper = mountComponent({ onCancel });
+    getButton(wrapper, 'cancel').trigger('click');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should execute cancel callback on Esc keydown', () => {
+    const escKeyCode = 27;
+    const onCancel = jest.fn();
+    mountComponent({ onCancel });
+    testingService.simulateKeydown(escKeyCode);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should execute confirm callback on confirm button click', () => {
+    const onConfirm = jest.fn();
+    const wrapper = mountComponent({ onConfirm });
+    getButton(wrapper, 'confirm').trigger('click');
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('should execute confirm callback on Enter keydown', () => {
+    const enterKeyCode = 13;
+    const onConfirm = jest.fn();
+    mountComponent({ onConfirm });
+    testingService.simulateKeydown(enterKeyCode);
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/src/vue/components/dialog/dialog.html
+++ b/src/vue/components/dialog/dialog.html
@@ -7,7 +7,7 @@
         v-html="title"
         data-dialog-title>
       </h2>
-      <span class="t-dialog-close-button-container">
+      <span class="t-dialog-close-button-container" v-if="!hideCloseButton">
         <t-button
           aria-label="close"
           theme="lookless"

--- a/src/vue/components/dialog/dialog.js
+++ b/src/vue/components/dialog/dialog.js
@@ -7,18 +7,18 @@ export const dialog = {
   components: {
     tButton: button
   },
-  props: ['width', 'title', 'onClose'],
+  props: ['width', 'title', 'onClose', 'hideCloseButton'],
   data(){
     return {
       keyboardSubscriptionId: null
     };
   },
   created(){
-    this.listenEscapeKeydown();
+    document.activeElement.blur();
+    if(!this.hideCloseButton) this.listenEscapeKeydown();
   },
   beforeDestroy(){
     this.dismissEscapeKeydown();
-
   },
   methods: {
     onCloseButtonClick(){
@@ -27,7 +27,9 @@ export const dialog = {
     listenEscapeKeydown(){
       const { subscribe } = keyboardSubscriptionService;
       const escKeyCode = 27;
-      if(this.onClose) this.keyboardSubscriptionId = subscribe(escKeyCode, () => this.onClose());
+      this.keyboardSubscriptionId = subscribe(escKeyCode, () => {
+        this.onClose && this.onClose();
+      });
     },
     dismissEscapeKeydown(){
       const { keyboardSubscriptionId } = this;

--- a/src/vue/components/dialog/dialog.test.js
+++ b/src/vue/components/dialog/dialog.test.js
@@ -13,6 +13,12 @@ describe('Dialog', () => {
     expect(wrapper.find('[data-dialog]').classes()).toContain('t-dialog');
   });
 
+  it('should deactivate any active element on document on create', () => {
+    document.activeElement.blur = jest.fn();
+    mountComponent();
+    expect(document.activeElement.blur).toHaveBeenCalled();
+  });
+
   it('should contain a backdrop', () => {
     const wrapper = mountComponent();
     expect(wrapper.classes()).toContain('t-dialog-backdrop');
@@ -48,12 +54,21 @@ describe('Dialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('should execute close callback on esc keydown event', () => {
+  it('should execute close callback on esc keydown event by default', () => {
     const escKeyCode = 27;
     const onClose = jest.fn();
     mountComponent({ onClose });
     testingService.simulateKeydown(escKeyCode);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should not execute close callback on esc keydown event if close button is hidden', () => {
+    const escKeyCode = 27;
+    const onClose = jest.fn();
+    const wrapper = mountComponent({ onClose, hideCloseButton: true });
+    testingService.simulateKeydown(escKeyCode);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(wrapper.findAll('[data-dialog-close-button]').length).toEqual(0);
   });
 
   it('should stop listening esc keydown event on unmount', () => {

--- a/src/vue/components/form/form.html
+++ b/src/vue/components/form/form.html
@@ -9,7 +9,7 @@
     :on-close="() => setBanner(null)"
     data-form-error-banner
   />
-  <div class="t-form-content">
+  <div class="t-form-content" aria-live="polite" :aria-busy="isBusy" data-form-content>
     <slot></slot>
   </div>
 </form>

--- a/src/vue/components/form/form.js
+++ b/src/vue/components/form/form.js
@@ -94,6 +94,9 @@ export const form = {
     classes(){
       const { isFetching, fetchFailed } = this;
       return formService.buildCssClasses({ fetching: isFetching, fetchFailed });
+    },
+    isBusy(){
+      return this.isFetching ? 'true' : 'false';
     }
   },
   template

--- a/src/vue/components/form/form.test.js
+++ b/src/vue/components/form/form.test.js
@@ -41,6 +41,24 @@ describe('Form', () => {
     });
   });
 
+  it('should form content be busy on fetch', () => {
+    const onFetch = jest.fn(() => new PromiseMock('success', { shouldAbort: true }));
+    wrapper = mountComponent({ onFetch });
+    wrapper.vm.$nextTick(() => {
+      expect(wrapper.find('[data-form-content]').attributes('aria-live')).toEqual('polite');
+      expect(wrapper.find('[data-form-content]').attributes('aria-busy')).toEqual('true');
+    });
+  });
+
+  it('should form content not be busy on fetch complete', () => {
+    const onFetch = jest.fn(() => new PromiseMock('success'));
+    wrapper = mountComponent({ onFetch });
+    wrapper.vm.$nextTick(() => {
+      expect(wrapper.find('[data-form-content]').attributes('aria-live')).toEqual('polite');
+      expect(wrapper.find('[data-form-content]').attributes('aria-busy')).toEqual('false');
+    });
+  });
+
   it('should hide loader on fetch complete', () => {
     const onFetch = jest.fn(() => new PromiseMock('success'));
     wrapper = mountComponent({ onFetch });

--- a/src/vue/index.js
+++ b/src/vue/index.js
@@ -1,4 +1,5 @@
 import * as components from '@vue/components';
+import confirm from '@vue/services/confirm/confirm';
 import dialog from '@vue/services/dialog/dialog';
 import toaster from '@vue/services/toaster/toaster';
 
@@ -9,6 +10,7 @@ export default {
       Vue.component(component.name, component);
     });
   },
+  confirm,
   dialog,
   toaster
 };

--- a/src/vue/services/confirm/confirm.doc.js
+++ b/src/vue/services/confirm/confirm.doc.js
@@ -1,0 +1,184 @@
+module.exports = {
+  name: 'Confirm',
+  description: 'Service to open confirmation dialogs.',
+  methods: [
+    {
+      name: 'open({ title, content, width, cancelButtonText, confirmButtonText, onCancel, onConfirm })',
+      params: [
+        {
+          name: 'content',
+          type: 'String, Vue Component',
+          values: 'Any',
+          description: 'Content to be shown in the dialog.',
+          required: true
+        },
+        {
+          name: 'title',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as confirm title.'
+        },
+        {
+          name: 'width',
+          type: 'String',
+          values: 'Any',
+          description: 'Sets how wide dialog can be.'
+        },
+        {
+          name: 'cancelButtonText',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as cancel button text'
+        },
+        {
+          name: 'confirmButtonText',
+          type: 'String',
+          values: 'Any',
+          description: 'Text to be used as confirm button text'
+        },
+        {
+          name: 'onCancel',
+          type: 'Function',
+          values: 'Any',
+          description: 'Listener to be executed on cancel button click'
+        },
+        {
+          name: 'onConfirm',
+          type: 'Function',
+          values: 'Any',
+          description: 'Listener to be executed on confirm button click',
+          required: true
+        }
+      ]
+    }
+  ],
+  examples: [
+    {
+      title: 'Default Confirm',
+      controller: {
+        methods: {
+          confirm(){
+            const { confirm } = taslonicVue;
+            confirm.open({
+              content: 'Are you sure?',
+              onConfirm: () => setTimeout(this.popConfirmation, 300)
+            });
+          },
+          popConfirmation(){
+            const { toaster } = taslonicVue;
+            toaster.pop({
+              theme: 'success',
+              title: 'Confirmed!',
+              message: 'You have confirmed.'
+            })
+          }
+        }
+      },
+      template: '<t-button @click="confirm">Confirm</t-button>'
+    },
+    {
+      title: 'Confirm with Title',
+      controller: {
+        methods: {
+          confirm(){
+            const { confirm } = taslonicVue;
+            confirm.open({
+              content: 'Are you sure you want to delete your account?',
+              title: 'Delete Account',
+              onConfirm: () => setTimeout(this.popConfirmation, 300)
+            });
+          },
+          popConfirmation(){
+            const { toaster } = taslonicVue;
+            toaster.pop({
+              theme: 'success',
+              title: 'Confirmed!',
+              message: 'You have confirmed.'
+            })
+          }
+        }
+      },
+      template: '<t-button @click="confirm">Confirm</t-button>'
+    },
+    {
+      title: 'Confirm with custom width',
+      description: 'Default confirm stretches up to 400px, but you can optionally set how wide it can be.',
+      controller: {
+        methods: {
+          confirm(){
+            const { confirm } = taslonicVue;
+            confirm.open({
+              content: `
+              <p>
+                This Confirm stretches up to <strong>700px</strong>.
+                On narrower screens it will fit properly.
+              </p>`,
+              title: 'Ther Wider Confirm',
+              width: '700px',
+              onConfirm: () => setTimeout(this.popConfirmation, 300)
+            });
+          },
+          popConfirmation(){
+            const { toaster } = taslonicVue;
+            toaster.pop({
+              theme: 'success',
+              title: 'Confirmed!',
+              message: 'You have confirmed.'
+            })
+          }
+        }
+      },
+      template: '<t-button @click="confirm">Confirm</t-button>'
+    },
+    {
+      title: 'Confirm with custom button texts',
+      controller: {
+        methods: {
+          confirm(){
+            const { confirm } = taslonicVue;
+            confirm.open({
+              content: 'Are you sure you want to send those invites?',
+              title: 'Invitation',
+              confirmButtonText: 'Yes, send them all!',
+              cancelButtonText: 'No, wait.',
+              onConfirm: () => setTimeout(this.popConfirmation, 300)
+            });
+          },
+          popConfirmation(){
+            const { toaster } = taslonicVue;
+            toaster.pop({
+              theme: 'success',
+              title: 'Confirmed!',
+              message: 'You have confirmed.'
+            })
+          }
+        }
+      },
+      template: '<t-button @click="confirm">Confirm</t-button>'
+    },
+    {
+      title: 'Confirm with cancel listener',
+      controller: {
+        methods: {
+          confirm(){
+            const { confirm } = taslonicVue;
+            confirm.open({
+              content: 'Are you sure?',
+              onConfirm: () => setTimeout(() => {
+                this.popConfirmation('Confirmed!', 'You have confirmed.', 'success')
+              }, 300),
+              onCancel: () => setTimeout(() => {
+                this.popConfirmation('Cancelled', 'You have cancelled.')
+              }, 300)
+            });
+          },
+          popConfirmation(title, message, theme){
+            const { toaster } = taslonicVue;
+            toaster.pop({ theme, title, message })
+          }
+        }
+      },
+      template: '<t-button @click="confirm">Confirm</t-button>'
+    }
+  ]
+}

--- a/src/vue/services/confirm/confirm.js
+++ b/src/vue/services/confirm/confirm.js
@@ -1,0 +1,54 @@
+import { confirm } from '@vue/components/confirm/confirm';
+import dialogService from '@vue/services/dialog/dialog';
+
+const _public = {};
+
+_public.open = ({
+  title,
+  width = '400px',
+  content,
+  cancelButtonText,
+  confirmButtonText,
+  onCancel,
+  onConfirm
+} = {}) => {
+  const dialog = dialogService.open({
+    title,
+    width,
+    content: buildConfirm({
+      content,
+      cancelButtonText,
+      confirmButtonText,
+      onCancel: () => handleCallbackOption(onCancel, dialog.close),
+      onConfirm: () => handleCallbackOption(onConfirm, dialog.close)
+    }),
+    name: 'confirm',
+    hideCloseButton: true
+  });
+};
+
+function buildConfirm({ content, cancelButtonText, confirmButtonText, onCancel, onConfirm }){
+  return {
+    components: {
+      tConfirm: confirm
+    },
+    data(){
+      return { cancelButtonText, confirmButtonText, onCancel, onConfirm };
+    },
+    template: `
+    <t-confirm
+      :cancelButtonText="cancelButtonText"
+      :confirmButtonText="confirmButtonText"
+      :onCancel="onCancel"
+      :onConfirm="onConfirm">
+      ${content}
+    </t-confirm>`
+  };
+}
+
+function handleCallbackOption(callback, closeDialog){
+  callback && callback();
+  closeDialog();
+}
+
+export default _public;

--- a/src/vue/services/confirm/confirm.test.js
+++ b/src/vue/services/confirm/confirm.test.js
@@ -1,0 +1,104 @@
+import dialogService from '@vue/services/dialog/dialog';
+import confirmService from './confirm';
+
+jest.useFakeTimers();
+
+describe('Confirm Service', () => {
+  beforeEach(() => {
+    jest.spyOn(dialogService, 'open');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function getButton(type){
+    const index = type == 'cancel' ? 0 : 1;
+    return document.querySelectorAll('button')[index];
+  }
+
+  it('should render a custom content', () => {
+    const content = '<p>Hello!</p>';
+    confirmService.open({ content });
+    expect(document.querySelector('p').textContent).toEqual('Hello!');
+  });
+
+  it('should open a dialog with confirm name', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'confirm' })
+    );
+  });
+
+  it('should open a dialog without close button', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ hideCloseButton: true })
+    );
+  });
+
+  it('should open a dialog 400px wide by default', () => {
+    confirmService.open();
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ width: '400px' })
+    );
+  });
+
+  it('should optionally open a dialog with custom width', () => {
+    const width = '300px';
+    confirmService.open({ width });
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ width: '300px' })
+    );
+  });
+
+  it('should optionally open a dialog with title', () => {
+    const title = 'Custom Title';
+    confirmService.open({ title });
+    expect(dialogService.open).toHaveBeenCalledWith(
+      expect.objectContaining({ title })
+    );
+  });
+
+  it('should execute cancel callback on cancel button click', () => {
+    const onCancel = jest.fn();
+    confirmService.open({ onCancel });
+    getButton('cancel').click();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('should close dialog on cancel button click', () => {
+    const content = { template: '<p>Hello!</p>' };
+    confirmService.open({ content });
+    getButton('cancel').click();
+    jest.runOnlyPendingTimers();
+    expect(document.querySelector('p')).toEqual(null);
+  });
+
+  it('should optionally set custom cancel button text', () => {
+    const cancelButtonText = 'Abort';
+    confirmService.open({ cancelButtonText });
+    expect(getButton('cancel').textContent.trim()).toEqual(cancelButtonText);
+  });
+
+  it('should execute confirm callback on confirm button click', () => {
+    const onConfirm = jest.fn();
+    confirmService.open({ onConfirm });
+    getButton('confirm').click();
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('should optionally set custom confirm button text', () => {
+    const confirmButtonText = 'Go!';
+    confirmService.open({ confirmButtonText });
+    expect(getButton('confirm').textContent.trim()).toEqual(confirmButtonText);
+  });
+
+  it('should close dialog on confirm button click', () => {
+    const content = { template: '<p>Hello!</p>' };
+    confirmService.open({ content });
+    getButton('confirm').click();
+    jest.runOnlyPendingTimers();
+    expect(document.querySelector('p')).toEqual(null);
+  });
+});

--- a/src/vue/services/dialog/dialog.doc.js
+++ b/src/vue/services/dialog/dialog.doc.js
@@ -3,7 +3,7 @@ module.exports = {
   description: 'Service to open dialogs.',
   methods: [
     {
-      name: 'open({ title, content, width, onClose })',
+      name: 'open({ title, content, width, hideCloseButton, onClose })',
       params: [
         {
           name: 'content',
@@ -23,6 +23,12 @@ module.exports = {
           type: 'String',
           values: 'Any',
           description: 'Sets how wide dialog can be.'
+        },
+        {
+          name: 'hideCloseButton',
+          type: 'Boolean',
+          values: 'true, false',
+          description: 'Hides dialog close button.'
         },
         {
           name: 'onClose',
@@ -127,15 +133,37 @@ module.exports = {
     },
     {
       title: 'Dialog closed programmatically',
+      description: 'You can optionally hide the dialog close button and take full control on how and when to close the dialog.',
       controller: {
         methods: {
           openDialog(){
             const { dialog } = taslonicVue;
             const selfClosingDialog = dialog.open({
-              content: 'This dialog will close in 3 seconds...',
+              content: {
+                data(){
+                  return {
+                    interval: null,
+                    count: 5
+                  };
+                },
+                mounted(){
+                  this.interval = window.setInterval(() => {
+                    --this.count;
+                    if(this.count === 0) selfClosingDialog.close()
+                  }, 1000);
+                },
+                beforeDestroy(){
+                  window.clearInterval(this.interval);
+                },
+                template: `
+                <span>
+                  This dialog will close in <strong>{{ count }}</strong> seconds...
+                </span>
+                `
+              },
               title: 'Self Closing Dialog',
+              hideCloseButton: true
             });
-            setTimeout(() => selfClosingDialog.close(), 3000);
           }
         }
       },

--- a/src/vue/services/dialog/dialog.test.js
+++ b/src/vue/services/dialog/dialog.test.js
@@ -25,11 +25,21 @@ describe('Dialog Service', () => {
     expect(document.querySelector('[data-dialog]').style.maxWidth).toEqual(width);
   });
 
+  it('should optionally set a custom dialog wrapper name', () => {
+    dialogService.open({ name: 'confirm' });
+    expect(document.querySelector('[data-confirm-wrapper]')).toBeDefined();
+  });
+
   it('should execute close callback on close', () => {
     const onClose = jest.fn();
     dialogService.open({ onClose });
     document.querySelector('[aria-label="close"]').click();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should optionally not render close button', () => {
+    dialogService.open({ hideCloseButton: true });
+    expect(document.querySelector('[aria-label="close"]')).toEqual(null);
   });
 
   it('should destroy dialog', () => {


### PR DESCRIPTION
## Issue

Resolves https://github.com/glorious-codes/glorious-taslonic/issues/14

## Solution

Create a confirm service that relies on the dialog service passing to it a specific kind of content.

- [x] Tested on Chrome
- [x] Tested on Firefox
- [x] Tested on Safari

## Links/Preview

![2020-11-27 16 44 41](https://user-images.githubusercontent.com/4738687/100480553-602fac80-30d0-11eb-868b-3d609027a8e7.gif)

