### PR TITLE
Renames blocked property name to block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/taslonic",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/taslonic",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "A glorious UI library available for React and Vue",
   "files": [
     "dist/**/*.*"

--- a/src/base/services/button/button.js
+++ b/src/base/services/button/button.js
@@ -4,7 +4,7 @@ import propBasedTagNameService from '@base/services/prop-based-tag-name/prop-bas
 
 const _public = {};
 
-_public.buildCssClasses = ({ theme, blocked } = {}) => {
+_public.buildCssClasses = ({ theme, block } = {}) => {
   const baseCssClass = getBaseCssClass();
   const cssClasses = [baseCssClass];
   propBasedCssClassService.handleProp(
@@ -14,7 +14,7 @@ _public.buildCssClasses = ({ theme, blocked } = {}) => {
     baseCssClass
   );
   propBasedCssClassService.handleBooleanProp(
-    { blocked },
+    { block },
     isValidBooleanProp,
     cssClasses,
     baseCssClass
@@ -46,7 +46,7 @@ function isValidTheme(theme){
 }
 
 function isValidBooleanProp(propName){
-  return ['blocked'].includes(propName);
+  return ['block'].includes(propName);
 }
 
 function isValidType(type){

--- a/src/base/services/button/button.test.js
+++ b/src/base/services/button/button.test.js
@@ -19,12 +19,12 @@ describe('Button Service', () => {
     expect(cssClasses).toEqual('t-button');
   });
 
-  it('should append blocked modifier css class if it has been given as true', () => {
-    const cssClasses = buttonService.buildCssClasses({ blocked: true });
-    expect(cssClasses).toEqual('t-button t-button-blocked');
+  it('should append block modifier css class if it has been given as true', () => {
+    const cssClasses = buttonService.buildCssClasses({ block: true });
+    expect(cssClasses).toEqual('t-button t-button-block');
   });
 
-  it('should not append blocked modifier css class if it has not been given', () => {
+  it('should not append block modifier css class if it has not been given', () => {
     const cssClasses = buttonService.buildCssClasses();
     expect(cssClasses).toEqual('t-button');
   });

--- a/src/base/services/field/field.js
+++ b/src/base/services/field/field.js
@@ -2,11 +2,11 @@ import propBasedCssClassService from '@base/services/prop-based-css-class/prop-b
 
 const _public = {};
 
-_public.buildCssClasses = ({ required, blocked, element } = {}) => {
+_public.buildCssClasses = ({ required, block, element } = {}) => {
   const baseCssClass = getBaseCssClass();
   const cssClasses = [baseCssClass, buildRequiredCssClass(required, element, baseCssClass)];
   propBasedCssClassService.handleBooleanProp(
-    { blocked },
+    { block },
     isValidBooleanProp,
     cssClasses,
     baseCssClass
@@ -19,7 +19,7 @@ function getBaseCssClass(){
 }
 
 function isValidBooleanProp(propName){
-  return ['blocked'].includes(propName);
+  return ['block'].includes(propName);
 }
 
 function buildRequiredCssClass(required, element, baseCssClass){

--- a/src/base/services/field/field.test.js
+++ b/src/base/services/field/field.test.js
@@ -23,8 +23,8 @@ describe('Field Service', () => {
     expect(cssClasses).toEqual('t-field');
   });
 
-  it('should append blocked modifier css class if it has been given as true', () => {
-    const cssClasses = fieldService.buildCssClasses({ blocked: true });
-    expect(cssClasses).toEqual('t-field t-field-blocked');
+  it('should append block modifier css class if it has been given as true', () => {
+    const cssClasses = fieldService.buildCssClasses({ block: true });
+    expect(cssClasses).toEqual('t-field t-field-block');
   });
 });

--- a/src/base/services/form-control/form-control.js
+++ b/src/base/services/form-control/form-control.js
@@ -4,12 +4,12 @@ import formService from '@base/services/form/form';
 
 const _public = {};
 
-_public.buildCssClasses = ({ errorMessage, blocked } = {}) => {
+_public.buildCssClasses = ({ errorMessage, block } = {}) => {
   const baseCssClass = getBaseCssClass();
   const cssClasses = [baseCssClass];
   handleInvalidCssClass(errorMessage, cssClasses, baseCssClass);
   propBasedCssClassService.handleBooleanProp(
-    { blocked },
+    { block },
     isValidBooleanProp,
     cssClasses,
     baseCssClass
@@ -30,7 +30,7 @@ function getBaseCssClass(){
 }
 
 function isValidBooleanProp(propName){
-  return ['blocked'].includes(propName);
+  return ['block'].includes(propName);
 }
 
 function handleInvalidCssClass(errorMessage, cssClasses, baseCssClass){

--- a/src/base/services/form-control/form-control.test.js
+++ b/src/base/services/form-control/form-control.test.js
@@ -14,9 +14,9 @@ describe('Form Control Service', () => {
     expect(cssClasses).toEqual('t-form-control');
   });
 
-  it('should append blocked modifier css class if it has been given as true', () => {
-    const cssClasses = formControlService.buildCssClasses({ blocked: true });
-    expect(cssClasses).toEqual('t-form-control t-form-control-blocked');
+  it('should append block modifier css class if it has been given as true', () => {
+    const cssClasses = formControlService.buildCssClasses({ block: true });
+    expect(cssClasses).toEqual('t-form-control t-form-control-block');
   });
 
   it('should build required validation model', () => {

--- a/src/base/styles/button.styl
+++ b/src/base/styles/button.styl
@@ -32,7 +32,7 @@
     color var(--t-color-grey)
     border-color var(--t-color-grey)
     cursor default
-  &.t-button-blocked
+  &.t-button-block
     display block
     width 100%
   &.t-button-primary

--- a/src/base/styles/field.styl
+++ b/src/base/styles/field.styl
@@ -1,6 +1,6 @@
 .t-field
   display inline-block
-  &.t-field-blocked
+  &.t-field-block
     display block
   &.t-field-required
     .t-field-label

--- a/src/base/styles/form-control.styl
+++ b/src/base/styles/form-control.styl
@@ -70,7 +70,7 @@ select-arrow()
       &:active
         box-shadow 0 0 0 4px var(--t-color-red-lighter)
         border-color var(--t-color-red)
-  &.t-form-control-blocked
+  &.t-form-control-block
     width 100%
     input,
     select,

--- a/src/react/components/button/button.doc.js
+++ b/src/react/components/button/button.doc.js
@@ -3,8 +3,8 @@ module.exports = {
   description: 'Abstraction of a native button.',
   properties: [
     {
-      name: 'blocked',
-      type: 'Boolean, String',
+      name: 'block',
+      type: 'Boolean',
       values: 'true, false'
     },
     {
@@ -38,8 +38,8 @@ module.exports = {
       }
     },
     {
-      title: 'Button blocked',
-      description: 'Blocked buttons behave like a block.',
+      title: 'Block Button',
+      description: 'Block property makes buttons behave like a block.',
       controller: function(){
         const { Button, Col, Row } = taslonicReact;
 
@@ -47,12 +47,12 @@ module.exports = {
           return (
             <Row>
               <Col sm="6">
-                <Button blocked>
+                <Button block>
                   Blocked Button
                 </Button>
               </Col>
               <Col sm="6">
-                <Button tag="a" blocked>
+                <Button tag="a" block>
                   Blocked Button
                 </Button>
               </Col>
@@ -89,12 +89,12 @@ module.exports = {
           return (
             <Row verticalAlign="middle">
               <Col sm="4">
-                <Button theme="primary" blocked>
+                <Button theme="primary" block>
                   Primary
                 </Button>
               </Col>
               <Col sm="4">
-                <Button theme="secondary" blocked>
+                <Button theme="secondary" block>
                   Secondary
                 </Button>
               </Col>
@@ -117,17 +117,17 @@ module.exports = {
           return (
             <Row verticalAlign="middle">
               <Col sm="3">
-                <Button theme="primary" blocked disabled>
+                <Button theme="primary" block disabled>
                   Primary
                 </Button>
               </Col>
               <Col sm="3">
-                <Button theme="secondary" blocked disabled>
+                <Button theme="secondary" block disabled>
                   Secondary
                 </Button>
               </Col>
               <Col sm="3">
-                <Button blocked disabled>
+                <Button block disabled>
                   Default
                 </Button>
               </Col>

--- a/src/react/components/button/button.js
+++ b/src/react/components/button/button.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import buttonService from '@base/services/button/button';
 import { Loader } from '@react/components/loader/loader';
 
-export const Button = ({ theme, blocked, tag, type = 'button', children, ...rest }) => {
+export const Button = ({ theme, block, tag, type = 'button', children, ...rest }) => {
   const { buildCssClasses, findParentFormModel } = buttonService;
   const TagName = buttonService.buildTagName(tag);
   const [submitting, setSubmitting] = useState();
@@ -31,7 +31,7 @@ export const Button = ({ theme, blocked, tag, type = 'button', children, ...rest
 
   return (
     <TagName
-      className={buildCssClasses({ theme, blocked })}
+      className={buildCssClasses({ theme, block })}
       tabIndex="0"
       type={type}
       ref={buttonEl}

--- a/src/react/components/button/button.test.js
+++ b/src/react/components/button/button.test.js
@@ -9,7 +9,7 @@ describe('Button', () => {
     return mount(
       <Button
         theme={ props.theme }
-        blocked={ props.blocked }
+        block={ props.block }
         tag={props.tag}
         { ...props }>
         { content }
@@ -48,9 +48,9 @@ describe('Button', () => {
     expect(getRootElProp(wrapper, 'className').includes('t-button-lookless')).toEqual(true);
   });
 
-  it('should optionally set as blocked', () => {
-    const wrapper = mountComponent({ blocked: true });
-    expect(getRootElProp(wrapper, 'className').includes('t-button-blocked')).toEqual(true);
+  it('should optionally set as block', () => {
+    const wrapper = mountComponent({ block: true });
+    expect(getRootElProp(wrapper, 'className').includes('t-button-block')).toEqual(true);
   });
 
   it('should optionally render custom attributes', () => {

--- a/src/react/components/field/field.doc.js
+++ b/src/react/components/field/field.doc.js
@@ -14,7 +14,7 @@ module.exports = {
       values: 'true, false'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     }
@@ -81,8 +81,8 @@ module.exports = {
       }
     },
     {
-      title: 'Blocked Field',
-      description: 'Blocked fields behave like a block.',
+      title: 'Block Field',
+      description: 'Block property makes fields behave like a block.',
       controller: function(){
         const { useState } = React;
         const { Field, Input, Row, Col } = taslonicReact;
@@ -93,13 +93,13 @@ module.exports = {
           return (
             <Row>
               <Col md="6">
-                <Field label="First Name" blocked>
-                  <Input blocked />
+                <Field label="First Name" block>
+                  <Input block />
                 </Field>
               </Col>
               <Col md="6">
-                <Field label="Last Name" blocked>
-                  <Input blocked />
+                <Field label="Last Name" block>
+                  <Input block />
                 </Field>
               </Col>
             </Row>

--- a/src/react/components/field/field.js
+++ b/src/react/components/field/field.js
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import fieldService from '@base/services/field/field';
 
-export const Field = ({ label, required, blocked, children }) => {
+export const Field = ({ label, required, block, children }) => {
   const [cssClasses, setCssClasses] = useState('');
   const fieldElement = useRef();
 
   useEffect(() => {
-    setCssClasses(buildCssClasses(required, blocked, fieldElement.current));
-  }, [required, blocked, fieldElement, setCssClasses]);
+    setCssClasses(buildCssClasses(required, block, fieldElement.current));
+  }, [required, block, fieldElement, setCssClasses]);
 
   return (
     <span ref={fieldElement} className={cssClasses}>
@@ -21,6 +21,6 @@ export const Field = ({ label, required, blocked, children }) => {
   );
 };
 
-function buildCssClasses(required, blocked, element){
-  return fieldService.buildCssClasses({ required, blocked, element });
+function buildCssClasses(required, block, element){
+  return fieldService.buildCssClasses({ required, block, element });
 }

--- a/src/react/components/field/field.test.js
+++ b/src/react/components/field/field.test.js
@@ -4,9 +4,9 @@ import { getRootElProp } from '@react/services/testing/testing';
 import { Field } from './field';
 
 describe('Field', () => {
-  function mountComponent({ label, required, blocked } = {}, content = <input />){
+  function mountComponent({ label, required, block } = {}, content = <input />){
     return mount(
-      <Field label={ label } required={ required } blocked={ blocked }>
+      <Field label={ label } required={ required } block={ block }>
         { content }
       </Field>
     );
@@ -26,6 +26,11 @@ describe('Field', () => {
   it('should contain required css class if required prop has been given as true', () => {
     const wrapper = mountComponent({ required: true });
     expect(getRootElProp(wrapper, 'className').includes('t-field-required')).toEqual(true);
+  });
+
+  it('should contain block css class if block prop has been given as true', () => {
+    const wrapper = mountComponent({ block: true });
+    expect(getRootElProp(wrapper, 'className').includes('t-field-block')).toEqual(true);
   });
 
   it('should contain required css class if no required prop has been passed but content is required', () => {

--- a/src/react/components/form-control/form-control.js
+++ b/src/react/components/form-control/form-control.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { FormControlModel } from '@base/models/form-control/form-control';
 import formControlService from '@base/services/form-control/form-control';
 
-export const FormControl = ({ value, required, validations, formControlElSelector, blocked, children }) => {
+export const FormControl = ({ value, required, validations, formControlElSelector, block, children }) => {
   const [formControlModel, setFormControlModel] = useState();
   const [currentValue, setCurrentValue] = useState(value);
   const [errorMessage, setErrorMessage] = useState();
@@ -34,7 +34,7 @@ export const FormControl = ({ value, required, validations, formControlElSelecto
   }, [required]);
 
   return (
-    <span className={buildCssClasses({ errorMessage, blocked })} ref={formControlEl}>
+    <span className={buildCssClasses({ errorMessage, block })} ref={formControlEl}>
       { children }
       <span className="t-form-control-error-message" data-form-control-error-message>
         { errorMessage }

--- a/src/react/components/form-control/form-control.test.js
+++ b/src/react/components/form-control/form-control.test.js
@@ -16,7 +16,7 @@ describe('Form Control', () => {
         required={ props.required }
         validations={ props.validations }
         formControlElSelector={ props.formControlElSelector || 'input' }
-        blocked={ props.blocked }>
+        block={ props.block }>
         { content }
       </FormControl>
     );
@@ -53,9 +53,9 @@ describe('Form Control', () => {
     expect(getRootElProp(wrapper, 'className').includes('t-form-control-invalid')).toEqual(true);
   });
 
-  it('should optionally set form control as blocked', () => {
-    const wrapper = mountComponent({ blocked: true });
-    expect(getRootElProp(wrapper, 'className').includes('t-form-control-blocked')).toEqual(true);
+  it('should optionally set form control as block', () => {
+    const wrapper = mountComponent({ block: true });
+    expect(getRootElProp(wrapper, 'className').includes('t-form-control-block')).toEqual(true);
   });
 
   it('should accept custom validations', () => {

--- a/src/react/components/input/input.doc.js
+++ b/src/react/components/input/input.doc.js
@@ -38,7 +38,7 @@ module.exports = {
       values: 'true, false'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -77,24 +77,24 @@ module.exports = {
             <>
               <Row>
                 <Col md="4">
-                  <Input type="email" placeholder="Email" blocked />
+                  <Input type="email" placeholder="Email" block />
                 </Col>
                 <Col md="4">
-                  <Input type="number" placeholder="Number" blocked />
+                  <Input type="number" placeholder="Number" block />
                 </Col>
                 <Col md="4">
-                  <Input type="password" placeholder="Password" blocked />
+                  <Input type="password" placeholder="Password" block />
                 </Col>
               </Row>
               <Row>
                 <Col md="4">
-                  <Input type="search" placeholder="Search" blocked />
+                  <Input type="search" placeholder="Search" block />
                 </Col>
                 <Col md="4">
-                  <Input type="tel" placeholder="Phone" blocked />
+                  <Input type="tel" placeholder="Phone" block />
                 </Col>
                 <Col md="4">
-                  <Input type="url" placeholder="URL" blocked />
+                  <Input type="url" placeholder="URL" block />
                 </Col>
               </Row>
             </>
@@ -185,8 +185,8 @@ module.exports = {
       }
     },
     {
-      title: 'Input blocked',
-      description: 'Blocked inputs behave like a block.',
+      title: 'Input block',
+      description: 'Block property makes inputs behave like a block.',
       controller: function(){
         const { Input, Row, Col } = taslonicReact;
 
@@ -194,13 +194,13 @@ module.exports = {
           return (
             <Row>
               <Col xs="4">
-                <Input blocked />
+                <Input block />
               </Col>
               <Col xs="4">
-                <Input blocked />
+                <Input block />
               </Col>
               <Col xs="4">
-                <Input blocked />
+                <Input block />
               </Col>
             </Row>
           );
@@ -251,7 +251,7 @@ module.exports = {
                   name="city"
                   placeholder="Enter your city name"
                   onChange={handleChange}
-                  blocked
+                  block
                 />
               </Col>
               <Col md="6">

--- a/src/react/components/input/input.js
+++ b/src/react/components/input/input.js
@@ -7,7 +7,7 @@ export const Input = ({
   value,
   placeholder,
   validations,
-  blocked,
+  block,
   disabled,
   required,
   ...rest
@@ -16,7 +16,7 @@ export const Input = ({
     <FormControl
       value={value}
       required={required}
-      blocked={blocked}
+      block={block}
       validations={validations}
       formControlElSelector="input"
     >

--- a/src/react/components/input/input.test.js
+++ b/src/react/components/input/input.test.js
@@ -11,7 +11,7 @@ describe('Input', () => {
         value={ props.value }
         placeholder={ props.placeholder }
         validations={ props.validations }
-        blocked={ props.blocked }
+        block={ props.block }
         disabled={ props.disabled }
         required={ props.required }
         { ...props }
@@ -31,10 +31,10 @@ describe('Input', () => {
     expect(wrapper.find(FormControl).prop('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.find(FormControl).prop('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.find(FormControl).prop('block')).toEqual(block);
   });
 
   it('should form control query for an input', () => {

--- a/src/react/components/select/select.doc.js
+++ b/src/react/components/select/select.doc.js
@@ -18,7 +18,7 @@ module.exports = {
       values: '[{ isValid: <Boolean> Function, errorMessage: String }]'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -83,8 +83,8 @@ module.exports = {
       `
     },
     {
-      title: 'Blocked Select',
-      description: 'Blocked selects behave like a block.',
+      title: 'Block Select',
+      description: 'Block property makes selects behave like a block.',
       controller: function(){
         const { Row, Col, Select } = taslonicReact;
 
@@ -92,21 +92,21 @@ module.exports = {
           return (
             <Row>
               <Col md="4">
-                <Select placeholder="Select" blocked>
+                <Select placeholder="Select" block>
                   <option value="apple">Apple</option>
                   <option value="orange">Orange</option>
                   <option value="banana">Banana</option>
                 </Select>
               </Col>
               <Col md="4">
-                <Select placeholder="Select" blocked>
+                <Select placeholder="Select" block>
                   <option value="rock">Rock</option>
                   <option value="punk">Punk</option>
                   <option value="samba">Samba</option>
                 </Select>
               </Col>
               <Col md="4">
-                <Select placeholder="Select" blocked>
+                <Select placeholder="Select" block>
                   <option value="football">Football</option>
                   <option value="basketball">Basketball</option>
                   <option value="baseboll">Baseboll</option>

--- a/src/react/components/select/select.js
+++ b/src/react/components/select/select.js
@@ -6,7 +6,7 @@ export const Select = ({
   value,
   placeholder,
   validations,
-  blocked,
+  block,
   disabled,
   required,
   children,
@@ -16,7 +16,7 @@ export const Select = ({
     <FormControl
       value={value}
       required={required}
-      blocked={blocked}
+      block={block}
       validations={validations}
       formControlElSelector="select"
     >

--- a/src/react/components/select/select.test.js
+++ b/src/react/components/select/select.test.js
@@ -9,7 +9,7 @@ describe('Select', () => {
       <Select
         value={ props.value }
         validations={ props.validations }
-        blocked={ props.blocked }
+        block={ props.block }
         disabled={ props.disabled }
         required={ props.required }
         { ...props }
@@ -37,10 +37,10 @@ describe('Select', () => {
     expect(wrapper.find(FormControl).prop('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.find(FormControl).prop('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.find(FormControl).prop('block')).toEqual(block);
   });
 
   it('should form control query for a select', () => {

--- a/src/react/components/textarea/textarea.doc.js
+++ b/src/react/components/textarea/textarea.doc.js
@@ -33,7 +33,7 @@ module.exports = {
       values: '[{ isValid: <Boolean> Function, errorMessage: String }]'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -125,8 +125,8 @@ module.exports = {
       }
     },
     {
-      title: 'Blocked Textarea',
-      description: 'Blocked textareas behave like a block.',
+      title: 'Block Textarea',
+      description: 'Block property makes textareas behave like a block.',
       controller: function(){
         const { Row, Col, Textarea } = taslonicReact;
 
@@ -134,10 +134,10 @@ module.exports = {
           return (
             <Row>
               <Col md="6">
-                <Textarea blocked />
+                <Textarea block />
               </Col>
               <Col md="6">
-                <Textarea blocked />
+                <Textarea block />
               </Col>
             </Row>
           )
@@ -204,7 +204,7 @@ module.exports = {
           return (
             <Row verticalAlign="middle">
               <Col md="6">
-                <Textarea onBlur={() => setCounter(counter + 1)} blocked />
+                <Textarea onBlur={() => setCounter(counter + 1)} block />
               </Col>
               {
                 counter > 0 &&

--- a/src/react/components/textarea/textarea.js
+++ b/src/react/components/textarea/textarea.js
@@ -7,7 +7,7 @@ export const Textarea = ({
   value,
   placeholder,
   validations,
-  blocked,
+  block,
   disabled,
   required,
   children,
@@ -17,7 +17,7 @@ export const Textarea = ({
     <FormControl
       value={value}
       required={required}
-      blocked={blocked}
+      block={block}
       validations={validations}
       formControlElSelector="textarea"
     >

--- a/src/react/components/textarea/textarea.test.js
+++ b/src/react/components/textarea/textarea.test.js
@@ -12,7 +12,7 @@ describe('Textarea', () => {
         placeholder={ props.placeholder }
         value={ props.value }
         validations={ props.validations }
-        blocked={ props.blocked }
+        block={ props.block }
         disabled={ props.disabled }
         required={ props.required }
         { ...props }
@@ -40,10 +40,10 @@ describe('Textarea', () => {
     expect(wrapper.find(FormControl).prop('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.find(FormControl).prop('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.find(FormControl).prop('block')).toEqual(block);
   });
 
   it('should form control query for a textarea', () => {

--- a/src/vue/components/button/button.doc.js
+++ b/src/vue/components/button/button.doc.js
@@ -3,8 +3,8 @@ module.exports = {
   description: 'Abstraction of a native button.',
   properties: [
     {
-      name: 'blocked',
-      type: 'Boolean, String',
+      name: 'block',
+      type: 'Boolean',
       values: 'true, false'
     },
     {
@@ -32,17 +32,17 @@ module.exports = {
       `
     },
     {
-      title: 'Button blocked',
-      description: 'Blocked buttons behave like a block.',
+      title: 'Block Button',
+      description: 'Block property makes buttons behave like a block.',
       template: `
       <t-row>
         <t-col sm="6">
-          <t-button blocked>
+          <t-button block>
             Blocked Button
           </t-button>
         </t-col>
         <t-col sm="6">
-          <t-button tag="a" blocked>
+          <t-button tag="a" block>
             Blocked Button
           </t-button>
         </t-col>
@@ -67,12 +67,12 @@ module.exports = {
       template: `
       <t-row vertical-align="middle">
         <t-col sm="4">
-          <t-button theme="primary" blocked>
+          <t-button theme="primary" block>
             Primary
           </t-button>
         </t-col>
         <t-col sm="4">
-          <t-button theme="secondary" blocked>
+          <t-button theme="secondary" block>
             Secondary
           </t-button>
         </t-col>
@@ -89,17 +89,17 @@ module.exports = {
       template: `
       <t-row vertical-align="middle">
         <t-col sm="3">
-          <t-button theme="primary" blocked disabled>
+          <t-button theme="primary" block disabled>
             Primary
           </t-button>
         </t-col>
         <t-col sm="3">
-          <t-button theme="secondary" blocked disabled>
+          <t-button theme="secondary" block disabled>
             Secondary
           </t-button>
         </t-col>
         <t-col sm="3">
-          <t-button blocked disabled>
+          <t-button block disabled>
             Default
           </t-button>
         </t-col>

--- a/src/vue/components/button/button.js
+++ b/src/vue/components/button/button.js
@@ -7,7 +7,7 @@ export const button = {
   components: {
     tLoader: loader
   },
-  props: ['theme', 'blocked', 'tag', 'type'],
+  props: ['theme', 'block', 'tag', 'type'],
   data(){
     return {
       submitting: false
@@ -32,8 +32,8 @@ export const button = {
   },
   computed: {
     classes(){
-      const { theme, blocked } = this;
-      return buttonService.buildCssClasses({ theme, blocked });
+      const { theme, block } = this;
+      return buttonService.buildCssClasses({ theme, block });
     },
     tagName(){
       return buttonService.buildTagName(this.tag);

--- a/src/vue/components/button/button.test.js
+++ b/src/vue/components/button/button.test.js
@@ -37,9 +37,9 @@ describe('Button', () => {
     expect(wrapper.classes()).toContain('t-button-lookless');
   });
 
-  it('should optionally set as blocked', () => {
-    const wrapper = mountComponent({ blocked: true });
-    expect(wrapper.classes()).toContain('t-button-blocked');
+  it('should optionally set as block', () => {
+    const wrapper = mountComponent({ block: true });
+    expect(wrapper.classes()).toContain('t-button-block');
   });
 
   it('should optionally set button listeners', () => {

--- a/src/vue/components/field/field.doc.js
+++ b/src/vue/components/field/field.doc.js
@@ -14,7 +14,7 @@ module.exports = {
       values: 'true, false'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     }
@@ -72,18 +72,18 @@ module.exports = {
       `
     },
     {
-      title: 'Blocked Field',
-      description: 'Blocked fields behave like a block.',
+      title: 'Block Field',
+      description: 'Block property makes fields behave like a block.',
       template: `
       <t-row>
         <t-col md="6">
-          <t-field label="First Name" blocked>
-            <t-input blocked />
+          <t-field label="First Name" block>
+            <t-input block />
           </t-field>
         </t-col>
         <t-col md="6">
-          <t-field label="Last Name" blocked>
-            <t-input blocked />
+          <t-field label="Last Name" block>
+            <t-input block />
           </t-field>
         </t-col>
       </t-row>

--- a/src/vue/components/field/field.js
+++ b/src/vue/components/field/field.js
@@ -3,7 +3,7 @@ import template from './field.html';
 
 export const field = {
   name: 't-field',
-  props: ['label', 'required', 'blocked'],
+  props: ['label', 'required', 'block'],
   data(){
     return {
       element: null
@@ -19,8 +19,8 @@ export const field = {
   },
   computed: {
     classes(){
-      const { required, blocked, element } = this;
-      return fieldService.buildCssClasses({ required, blocked, element });
+      const { required, block, element } = this;
+      return fieldService.buildCssClasses({ required, block, element });
     }
   },
   template

--- a/src/vue/components/field/field.test.js
+++ b/src/vue/components/field/field.test.js
@@ -22,6 +22,11 @@ describe('Field', () => {
     expect(wrapper.classes()).toContain('t-field-required');
   });
 
+  it('should contain block css class if block prop has been given as true', () => {
+    const wrapper = mount({ block: true });
+    expect(wrapper.classes()).toContain('t-field-block');
+  });
+
   it('should contain required css class if no required prop has been passed but content is required', () => {
     const wrapper = mount({}, '<input type="text" required />');
     wrapper.vm.$nextTick(() => {

--- a/src/vue/components/form-control/form-control.js
+++ b/src/vue/components/form-control/form-control.js
@@ -4,7 +4,7 @@ import template from './form-control.html';
 
 export const formControl = {
   name: 't-form-control',
-  props: ['value', 'required', 'autofocus', 'validations', 'formControlElSelector', 'blocked'],
+  props: ['value', 'required', 'autofocus', 'validations', 'formControlElSelector', 'block'],
   data(){
     return {
       errorMessage: '',
@@ -48,8 +48,8 @@ export const formControl = {
   },
   computed: {
     classes(){
-      const { blocked, errorMessage } = this;
-      return formControlService.buildCssClasses({ blocked, errorMessage });
+      const { block, errorMessage } = this;
+      return formControlService.buildCssClasses({ block, errorMessage });
     }
   },
   template

--- a/src/vue/components/form-control/form-control.test.js
+++ b/src/vue/components/form-control/form-control.test.js
@@ -37,9 +37,9 @@ describe('Form Control', () => {
     });
   });
 
-  it('should optionally set form control as blocked', () => {
-    const wrapper = mount({ blocked: true });
-    expect(wrapper.classes()).toContain('t-form-control-blocked');
+  it('should optionally set form control as block', () => {
+    const wrapper = mount({ block: true });
+    expect(wrapper.classes()).toContain('t-form-control-block');
   });
 
   it('should emit input value when user fills input', () => {

--- a/src/vue/components/input/input.doc.js
+++ b/src/vue/components/input/input.doc.js
@@ -38,7 +38,7 @@ module.exports = {
       values: 'true, false'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -73,7 +73,7 @@ module.exports = {
       <div>
         <t-row vertical-align="middle">
           <t-col md="3">
-            <t-input v-model="name" placeholder="Enter your name" blocked />
+            <t-input v-model="name" placeholder="Enter your name" block />
           </t-col>
           <t-col md="3" v-if="name">
             Name: {{ name }}
@@ -89,24 +89,24 @@ module.exports = {
       <div>
         <t-row>
           <t-col md="4">
-            <t-input type="email" placeholder="Email" blocked />
+            <t-input type="email" placeholder="Email" block />
           </t-col>
           <t-col md="4">
-            <t-input type="number" placeholder="Number" blocked />
+            <t-input type="number" placeholder="Number" block />
           </t-col>
           <t-col md="4">
-            <t-input type="password" placeholder="Password" blocked />
+            <t-input type="password" placeholder="Password" block />
           </t-col>
         </t-row>
         <t-row>
           <t-col md="4">
-            <t-input type="search" placeholder="Search" blocked />
+            <t-input type="search" placeholder="Search" block />
           </t-col>
           <t-col md="4">
-            <t-input type="tel" placeholder="Phone" blocked />
+            <t-input type="tel" placeholder="Phone" block />
           </t-col>
           <t-col md="4">
-            <t-input type="url" placeholder="URL" blocked />
+            <t-input type="url" placeholder="URL" block />
           </t-col>
         </t-row>
       </div>
@@ -158,18 +158,18 @@ module.exports = {
       `
     },
     {
-      title: 'Input blocked',
-      description: 'Blocked inputs behave like a block.',
+      title: 'Input block',
+      description: 'Block property makes inputs behave like a block.',
       template: `
       <t-row>
         <t-col xs="4">
-          <t-input blocked />
+          <t-input block />
         </t-col>
         <t-col xs="4">
-          <t-input blocked />
+          <t-input block />
         </t-col>
         <t-col xs="4">
-          <t-input blocked />
+          <t-input block />
         </t-col>
       </t-row>
       `
@@ -204,7 +204,7 @@ module.exports = {
       <div>
         <t-row vertical-align="middle">
           <t-col md="3">
-            <t-input @blur="count" blocked />
+            <t-input @blur="count" block />
           </t-col>
           <t-col md="3" v-if="counter">
             Blurred {{ counter }}x

--- a/src/vue/components/input/input.html
+++ b/src/vue/components/input/input.html
@@ -1,7 +1,7 @@
 <t-form-control
   :value="value"
   :required="required"
-  :blocked="blocked"
+  :block="block"
   :validations="validations"
   form-control-el-selector="input"
 >

--- a/src/vue/components/input/input.js
+++ b/src/vue/components/input/input.js
@@ -15,7 +15,7 @@ export const input = {
     validations: { type: Array },
     autofocus: { type: Boolean },
     readonly: { type: Boolean },
-    blocked: { type: Boolean },
+    block: { type: Boolean },
     required: { type: Boolean },
     disabled: { type: Boolean }
   },

--- a/src/vue/components/input/input.test.js
+++ b/src/vue/components/input/input.test.js
@@ -25,10 +25,10 @@ describe('Input', () => {
     expect(wrapper.findComponent(formControl).props('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.findComponent(formControl).props('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.findComponent(formControl).props('block')).toEqual(block);
   });
 
   it('should form control query for an input', () => {

--- a/src/vue/components/select/select.doc.js
+++ b/src/vue/components/select/select.doc.js
@@ -23,7 +23,7 @@ module.exports = {
       values: '[{ isValid: <Boolean> Function, errorMessage: String }]'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -127,26 +127,26 @@ module.exports = {
       `
     },
     {
-      title: 'Blocked Select',
-      description: 'Blocked selects behave like a block.',
+      title: 'Block Select',
+      description: 'Block property makes selects behave like a block.',
       template: `
       <t-row>
         <t-col md="4">
-          <t-select placeholder="Select" blocked>
+          <t-select placeholder="Select" block>
             <option value="apple">Apple</option>
             <option value="orange">Orange</option>
             <option value="banana">Banana</option>
           </t-select>
         </t-col>
         <t-col md="4">
-          <t-select placeholder="Select" blocked>
+          <t-select placeholder="Select" block>
             <option value="rock">Rock</option>
             <option value="punk">Punk</option>
             <option value="samba">Samba</option>
           </t-select>
         </t-col>
         <t-col md="4">
-          <t-select placeholder="Select" blocked>
+          <t-select placeholder="Select" block>
             <option value="football">Football</option>
             <option value="basketball">Basketball</option>
             <option value="baseboll">Baseboll</option>
@@ -203,7 +203,7 @@ module.exports = {
       <div>
         <t-row vertical-align="middle">
           <t-col md="3">
-            <t-select @blur="count" placeholder="Select" blocked>
+            <t-select @blur="count" placeholder="Select" block>
               <option value="apple">Apple</option>
               <option value="orange">Orange</option>
               <option value="banana">Banana</option>

--- a/src/vue/components/select/select.html
+++ b/src/vue/components/select/select.html
@@ -1,7 +1,7 @@
 <t-form-control
   :value="value"
   :required="required"
-  :blocked="blocked"
+  :block="block"
   :validations="validations"
   form-control-el-selector="select"
 >

--- a/src/vue/components/select/select.js
+++ b/src/vue/components/select/select.js
@@ -13,7 +13,7 @@ export const select = {
     placeholder: { type: String },
     validations: { type: Array },
     autofocus: { type: Boolean },
-    blocked: { type: Boolean },
+    block: { type: Boolean },
     required: { type: Boolean },
     disabled: { type: Boolean }
   },

--- a/src/vue/components/select/select.test.js
+++ b/src/vue/components/select/select.test.js
@@ -25,10 +25,10 @@ describe('Select', () => {
     expect(wrapper.findComponent(formControl).props('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.findComponent(formControl).props('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.findComponent(formControl).props('block')).toEqual(block);
   });
 
   it('should form control query for a select', () => {

--- a/src/vue/components/textarea/textarea.doc.js
+++ b/src/vue/components/textarea/textarea.doc.js
@@ -33,7 +33,7 @@ module.exports = {
       values: '[{ isValid: <Boolean> Function, errorMessage: String }]'
     },
     {
-      name: 'blocked',
+      name: 'block',
       type: 'Boolean',
       values: 'true, false'
     },
@@ -77,7 +77,7 @@ module.exports = {
       template: `
       <t-row vertical-align="middle">
         <t-col md="6">
-          <t-textarea v-model="bio" placeholder="Tell us a bit about you..." blocked />
+          <t-textarea v-model="bio" placeholder="Tell us a bit about you..." block />
         </t-col>
         <t-col md="6" v-if="bio">
           Bio: {{ bio }}
@@ -120,15 +120,15 @@ module.exports = {
       `
     },
     {
-      title: 'Blocked Textarea',
-      description: 'Blocked textareas behave like a block.',
+      title: 'Block Textarea',
+      description: 'Block property makes textareas behave like a block.',
       template: `
       <t-row>
         <t-col md="6">
-          <t-textarea blocked />
+          <t-textarea block />
         </t-col>
         <t-col md="6">
-          <t-textarea blocked />
+          <t-textarea block />
         </t-col>
       </t-row>
       `
@@ -174,7 +174,7 @@ module.exports = {
       template: `
       <t-row vertical-align="middle">
         <t-col md="6">
-          <t-textarea @blur="count" blocked />
+          <t-textarea @blur="count" block />
         </t-col>
         <t-col md="6" v-if="counter">
           Blurred {{ counter }}x

--- a/src/vue/components/textarea/textarea.html
+++ b/src/vue/components/textarea/textarea.html
@@ -1,7 +1,7 @@
 <t-form-control
   :value="value"
   :required="required"
-  :blocked="blocked"
+  :block="block"
   :validations="validations"
   form-control-el-selector="textarea"
 >

--- a/src/vue/components/textarea/textarea.js
+++ b/src/vue/components/textarea/textarea.js
@@ -15,7 +15,7 @@ export const textarea = {
     validations: { type: Array },
     autofocus: { type: Boolean },
     readonly: { type: Boolean },
-    blocked: { type: Boolean },
+    block: { type: Boolean },
     required: { type: Boolean },
     disabled: { type: Boolean }
   },

--- a/src/vue/components/textarea/textarea.test.js
+++ b/src/vue/components/textarea/textarea.test.js
@@ -25,10 +25,10 @@ describe('Select', () => {
     expect(wrapper.findComponent(formControl).props('validations')).toEqual(validations);
   });
 
-  it('should pass blocked to form control', () => {
-    const blocked = true;
-    const wrapper = mount({ blocked });
-    expect(wrapper.findComponent(formControl).props('blocked')).toEqual(blocked);
+  it('should pass block to form control', () => {
+    const block = true;
+    const wrapper = mount({ block });
+    expect(wrapper.findComponent(formControl).props('block')).toEqual(block);
   });
 
   it('should form control query for a textarea', () => {


### PR DESCRIPTION
## Issue

Resolves https://github.com/glorious-codes/glorious-taslonic/issues/65

## Solution

Renamed `blocked` property name to `block`.

- [x] Tested on Chrome
- [x] Tested on Firefox
- [x] Tested on Safari
