### PR TITLE
Minor fixes on Alert and Toaster docs (React)

### DIFF
--- a/src/react/services/alert/alert.doc.js
+++ b/src/react/services/alert/alert.doc.js
@@ -7,7 +7,7 @@ module.exports = {
       params: [
         {
           name: 'content',
-          type: 'String, Vue Component',
+          type: 'String, React Node',
           values: 'Any',
           description: 'Content to be shown in the dialog.',
           required: true

--- a/src/react/services/toaster/toaster.doc.js
+++ b/src/react/services/toaster/toaster.doc.js
@@ -65,21 +65,6 @@ module.exports = {
     {
       title: 'Toast with theme',
       description: 'You can optionally set a theme to the toast.',
-      controller: {
-        methods: {
-          pop(theme){
-            const { toaster } = taslonicVue;
-            toaster.pop({
-              title: this.capitalize(theme),
-              message: `This is a <i>${theme}</i> toast.`,
-              theme
-            });
-          },
-          capitalize([ firstLetter, ...rest ]){
-            return [firstLetter.toUpperCase(), ...rest].join('');
-          }
-        }
-      },
       controller: function(){
         const { Button, Col, Row, toaster } = taslonicReact;
 


### PR DESCRIPTION
## Issue

Docs were showing misleading Alert prop and Toaster example.

## Solution

Fixed prop table info for Alert.
Fixed toaster import on Toaster example.


- [x] Tested on Chrome
- [x] Tested on Firefox
- [x] Tested on Safari

## Links/Preview

N/A
